### PR TITLE
Duplication d'une annotation d'une dérivée partielle

### DIFF
--- a/3_gradient.jl
+++ b/3_gradient.jl
@@ -78,7 +78,7 @@ $$\nabla f = (\partial f/\partial x, \partial f/\partial y)$$
 md"""
 ## Calculer le gradient à la main
 
-Comment calculer les valeurs de $\partial f/\partial x$ et $\partial f/\partial x$ ?
+Comment calculer les valeurs de $\partial f/\partial x$ et $\partial f/\partial y$ ?
 Commençant par voir comment faire ça à la main. Nous verrons au cours suivant comment le calculer algorithmiquement.
 L'astuce: pour calculer $\frac{\partial}{\partial x}f(x, y)$, il faut voir $y$ comme constant et donc voir $f$ comme fonction de $x$ uniquement. Par exemple:
 


### PR DESCRIPTION
J'ai remarqué qu'il y avait une dérivée partielle de **df/dx** et de **df/dx**, cependant je pense que ce dernier doit être sur ce format-là: **df/dx et df/dy**

Veuillez m'excuser si j'ai mal compris la description.

Kaan Akman

<img width="862" alt="Screenshot 2024-11-24 at 16 36 02" src="https://github.com/user-attachments/assets/df30999d-b920-4002-a28c-aaeaff619758">
