### PR TITLE
Théorème de Bézout correction Pgcd(x,y)->Pgcd(a,b) + preuve que Pgcd(a,b) divise c   c= ax+by

### DIFF
--- a/1_complex.jl
+++ b/1_complex.jl
@@ -86,7 +86,23 @@ md"Tout polynome ``a_0 + a_1 x + a_2 x^2 + \cdots + a_n x^n`` de degré ``n`` a 
 md"### La multiplicité"
 
 # ╔═╡ 64777fee-6b30-417a-a705-279c710b67cf
-md"TODO"
+md"## Propriété des paires conjuguées
+
+Si \( P(x) \) a des coefficients réels et qu'une racine complexe \( z = a + ib \) (avec \( a, b \in \mathbb{R} \)) est une solution, alors la racine conjuguée \( \overline{z} = a - ib \) est également une solution.
+
+### Multiplicité
+
+La multiplicité d'une racine \( z \) est définie comme le nombre de fois où \( z \) apparaît comme solution de \( P(x) = 0 \).  
+Cela revient à l'exposant du facteur \( (x - z) \) dans la décomposition factorielle du polynôme. Par exemple, si :  
+\[
+P(x) = (x - z)^m \cdot Q(x),
+\]
+où \( Q(z) \neq 0 \), alors \( z \) est une racine de multiplicité \( m \).
+
+### Cas des paires conjuguées
+
+Si \( z = a + ib \) est une racine de multiplicité \( m \), alors la racine conjuguée \( \overline{z} = a - ib \) possède également une multiplicité \( m \).
+"
 
 # ╔═╡ 0ea1f264-d98e-4773-9ffd-5a070b7afc1b
 md"### Le cas quadratique"

--- a/4_autodiff.jl
+++ b/4_autodiff.jl
@@ -749,7 +749,7 @@ J_{1,n} = J_{k+1,n} J_{1,k} \qquad \Omega(d_nd_kd_0)
 ```
 we have a complexity of
 ```math
-\Omega(d_nd_kd_0 + \sum_{i=1}^{k-1} d_kd_id_{i-1} + \sum_{i=k}^{n} d_id_{i-1}d_k).
+\Omega(d_nd_kd_0 + \sum_{i=1}^{k-1} d_kd_id_{i-1} + \sum_{i=k+2}^{n} d_id_{i-1}d_k).
 ```
 
 #### Comparison

--- a/6_number.jl
+++ b/6_number.jl
@@ -48,8 +48,10 @@ md"""
 """
 
 # ╔═╡ 7bad8c6c-45c7-402f-ad59-6857e9268901
-qa(md"Comment prouver que l'égalité ``ax + by = c`` implique que ``\text{gcd}(x, y)`` divise ``c`` ?",
+qa(md"Comment prouver que l'égalité ``ax + by = c`` implique que ``\text{gcd}(a, b)`` divise ``c`` ?",
 md"""
+	L'égalité \(ax + by = c\) implique que \(\text{pgcd}(a, b)\) divise \(c\), car \(c\) est une combinaison linéaire de \(a\) et \(b\), et toute combinaison linéaire de \(a\) et \(b\) est un multiple du \(\text{pgcd}(a, b)\).
+
 """,)
 
 # ╔═╡ cd481f6c-66f4-4ebf-9769-c3edc24f403b


### PR DESCRIPTION
La question ici est :
"Comment prouver que l'égalité ax+by=c implique que gcd(x,y) divise c ?"
Je pense qu'il y a une confusion ici, et que cela devrait être gcd(a,b) à la place de gcd(x,y), comme mentionné dans la définition :
"L'égalité ax+by=c est vraie si et seulement si gcd(a,b)divise c ."

Noah 