### PR TITLE
Update tp4_corr.tex

### DIFF
--- a/Exercises/2025/tp4_corr.tex
+++ b/Exercises/2025/tp4_corr.tex
@@ -341,7 +341,7 @@
 
         \item Si $p = 7, \quad 2^3 \equiv 8 \equiv 1 \pmod{7} \rightarrow 1$ donc 2 est un résidu quadratique modulo 7.
          \(
-        \text{On peut vérifier en testant si un carré donne 2 modulo 5:} \\
+        \text{On peut vérifier en testant si un carré donne 2 modulo 7:} \\
         1^2 \equiv 1 \pmod{7} \\
         2^2 \equiv 4 \pmod{7} \\
         3^2 \equiv 9 \equiv 2 \pmod{7} \Rightarrow \text{TOP}


### PR DESCRIPTION
Dans l'exercice 27 tp4, quand p=7, lors de la vérification, il est écrit "On peut vérifier en testant si un carré donne 2 modulo 5" mais il devrait être écrit "On peut vérifier en testant si un carré donne 2 modulo 7" Bonne journée !