### PR TITLE
Fix formatting in q3.tex solution explanation

### DIFF
--- a/Exams/2025_01/q3.tex
+++ b/Exams/2025_01/q3.tex
@@ -25,7 +25,7 @@ pour $n = 2025$ ?
     Expliquez comment calculer cette exponentiation avec une complexité proportionnelle au logarithme de $n$.
 \begin{solutionbox}{7.5cm}
     En binaire, 2025 vaut 11111101001.
-    On a donc $3^2025 = 3^1 + 3^8 + 3^{32} + 3^{128} + 3^{256} + 3^{512} + 3^{1024}$.
+    On a donc $3^{2025} = 3^1 + 3^8 + 3^{32} + 3^{128} + 3^{256} + 3^{512} + 3^{1024}$.
     Il suffit alors de calculer les puissances $3^{2^k}$ l'une après l'autre jusque $k=10$ en utilisant le fait que
     $3^{2^{k+1}} \equiv (3^{2^k})^2 \pmod{7}$.
     Il suffit ensuite de sommes celles qui correspondent à un 1 dans la représentation binaire.


### PR DESCRIPTION
Fix typo in exponent: only "2" was superscript instead of "2025" (no mathematical error)